### PR TITLE
CSSグローバル設定追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel
@@ -34,3 +35,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
+// import "./globals.css";
+import "../css/global.css"
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import styles from './page.module.css'
+// import styles from './page.module.css'
 import { client } from '../../libs/client'
 
 export default async function Home() {
@@ -7,9 +7,15 @@ export default async function Home() {
   })
 
   return (
+    <main>
+      <h1>h1: サイト名</h1>
+      <h2>h2: サイト名</h2>
+      <p>{data.title}</p>
+    </main>
+    /*
     <main className={styles.main}>
-
       <div className={styles.center}>{data.title}</div>
     </main>
+    */
   )
 }

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1,0 +1,40 @@
+@import url("./reset.css");
+
+/* 変数の宣言など */
+:root {
+  /* サイトのテーマカラー */
+  --main-color: #399;
+
+  /* サイトのサブカラー */
+  --sub-color: #61e;
+}
+
+/* 以下、サイト全体のスタイル設定 */
+html {
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Roboto,
+    "Segoe UI",
+    "Helvetica Neue",
+    HelveticaNeue,
+    YuGothic,
+    "Yu Gothic Medium",
+    "Yu Gothic",
+    Verdana,
+    Meiryo,
+    sans-serif;
+  scroll-behavior: smooth;
+}
+
+body {
+  color: #444;
+}
+
+h1 {
+  color: var(--main-color);
+}
+
+h2 {
+  color: var(--sub-color);
+}

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,0 +1,5 @@
+/*
+  Josh's Custom CSS Reset
+  https://www.joshwcomeau.com/css/custom-css-reset/
+*/
+*,*::before,*::after{box-sizing:border-box}*{margin:0}body{line-height:1.5;-webkit-font-smoothing:antialiased}img,picture,video,canvas,svg{display:block;max-width:100%}input,button,textarea,select{font:inherit}p,h1,h2,h3,h4,h5,h6{overflow-wrap:break-word}#root,#__next{isolation:isolate}


### PR DESCRIPTION
サイト全域に適用するスタイル関連のCSSを追加しました

- src/css/global.css
サイト全域に適用するCSSファイルです。サイト全体で使う変数の定義や、フォントの設定を行います。
後述するリセットCSSも読み込んでいるので、サイト全体にリセットCSSが適用されます

- src/css/reset.css 
リセットCSSです